### PR TITLE
Add OrderedMap to enable key-value syntax with keys that are not unique

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "serde_tokenstream"
-version = "0.1.5"
+version = "0.1.6-dev"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::procedural-macro-helpers", "parsing"]
 [dependencies]
 proc-macro2  = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-syn = { version = "1.0", features = ["full", "extra-traits"] }
+syn = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
 quote = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_tokenstream"
-version = "0.1.5"
+version = "0.1.6-dev"
 authors = ["Adam H. Leventhal <ahl@oxide.computer>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ be... whatever... `String`s! You can't use `serde_json::Value` as the key in a
 let config = from_tokenstream::<OrderedMap<serde_json::Value, String>>(tokens)?;
 ```
 
-The macro can consume input like this:
+The macro can then be invoked like this:
 
 ```rust
 my_macro!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 Oxide Computer Company
 
-//! This is a `serde::Deserializer` implementation for
-//! `proc_macro2::TokenStream`. It is intended for proc_macro builders who want
-//! rich configuration in their custom attributes.
+//! This is a [`serde::Deserializer`] implementation for
+//! [`proc_macro2::TokenStream`]. It is intended for proc_macro builders who
+//! want rich configuration in their custom attributes.
 //!
 //! If you'd like the consumers of your macro use it like this:
 //!
@@ -50,10 +50,12 @@
 //! ```
 
 mod ibidem;
+mod ordered_map;
 mod serde_tokenstream;
 
 pub use crate::ibidem::ParseWrapper;
 pub use crate::ibidem::TokenStreamWrapper;
+pub use crate::ordered_map::OrderedMap;
 pub use crate::serde_tokenstream::from_tokenstream;
 pub use crate::serde_tokenstream::Error;
 pub use crate::serde_tokenstream::Result;

--- a/src/ordered_map.rs
+++ b/src/ordered_map.rs
@@ -1,0 +1,102 @@
+// Copyright 2022 Oxide Computer Company
+
+use std::marker::PhantomData;
+
+use serde::{de::Visitor, Deserialize};
+
+/// This is a container for pairs that are deserialized from map syntax
+/// without requiring the keys to be unique. This is useful for types that
+/// don't implement traits such as `Hash` or `Ord` required for map types that
+/// offer efficient lookups. The only mechanism to extract data is via
+/// `into_iter()`.
+pub struct OrderedMap<K, V> {
+    items: Vec<(K, V)>,
+}
+
+impl<K, V> Default for OrderedMap<K, V> {
+    fn default() -> Self {
+        Self {
+            items: Default::default(),
+        }
+    }
+}
+
+impl<'de, K: Deserialize<'de>, V: Deserialize<'de>> Deserialize<'de>
+    for OrderedMap<K, V>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(OrderedMapVisitor(PhantomData))
+    }
+}
+
+struct OrderedMapVisitor<K, V>(PhantomData<(K, V)>);
+
+impl<'de, K: Deserialize<'de>, V: Deserialize<'de>> Visitor<'de>
+    for OrderedMapVisitor<K, V>
+{
+    type Value = OrderedMap<K, V>;
+
+    fn expecting(
+        &self,
+        formatter: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        formatter.write_str("a map of key-value pairs")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut items = Vec::with_capacity(map.size_hint().unwrap_or(0));
+        while let Some(entry) = map.next_entry()? {
+            items.push(entry)
+        }
+        Ok(OrderedMap {
+            items,
+        })
+    }
+}
+
+impl<K, V> IntoIterator for OrderedMap<K, V> {
+    type Item = (K, V);
+
+    type IntoIter = std::vec::IntoIter<(K, V)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+    use serde::Deserialize;
+
+    use crate::{from_tokenstream, Result};
+
+    use super::OrderedMap;
+
+    // Note that critically this isn't Ord, or Hash, or whatever so could not be
+    // used in a HashMap or BTreeMap.
+    #[derive(Deserialize)]
+    #[serde(transparent)]
+    struct Value(pub String);
+
+    #[test]
+    fn test_ordered_map() -> Result<()> {
+        let data = from_tokenstream::<OrderedMap<Value, Value>>(&quote! {
+            "key" = "value1",
+            "key" = "value2"
+        })?;
+
+        let mut kv = data.into_iter().map(|(k, v)| (k.0, v.0));
+        assert_eq!(kv.next(), Some(("key".to_string(), "value1".to_string())));
+        assert_eq!(kv.next(), Some(("key".to_string(), "value2".to_string())));
+        assert_eq!(kv.next(), None);
+
+        Ok(())
+    }
+}

--- a/src/serde_tokenstream.rs
+++ b/src/serde_tokenstream.rs
@@ -81,7 +81,7 @@ where
 }
 
 #[derive(Clone, Debug)]
-enum InternalError {
+pub(crate) enum InternalError {
     Normal(Error),
     NoData(String),
     Unknown,

--- a/src/serde_tokenstream.rs
+++ b/src/serde_tokenstream.rs
@@ -81,7 +81,7 @@ where
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum InternalError {
+enum InternalError {
     Normal(Error),
     NoData(String),
     Unknown,

--- a/src/serde_tokenstream.rs
+++ b/src/serde_tokenstream.rs
@@ -1513,7 +1513,6 @@ mod tests {
         };
     }
 
-    #[derive(Debug)]
     enum ClosureOrPath {
         Closure(syn::ExprClosure),
         Path(syn::Path),
@@ -1547,7 +1546,7 @@ mod tests {
 
     #[test]
     fn test_token_stream_wrapper() {
-        #[derive(Debug, Deserialize)]
+        #[derive(Deserialize)]
         struct Stuff {
             pre_tokens: ParseWrapper<ClosureOrPath>,
             text: String,


### PR DESCRIPTION
Intending to use this in typify and progenitor.