### PR TITLE
improve error reporting if outer delimiters are available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target/
+/target
 */target/
 **/*.rs.bk

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 */target/
 **/*.rs.bk
+/.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-    "rewrap.wrappingColumn": 79,
-    "rust-analyzer.rustfmt.overrideCommand": [
-        "rustup",
-        "run",
-        "nightly",
-        "rustfmt"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "rewrap.wrappingColumn": 79,
     "rust-analyzer.rustfmt.overrideCommand": [
         "rustup",
         "run",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,8 +121,10 @@ name = "testlib"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
+ "quote",
  "serde",
  "serde_tokenstream",
+ "syn",
 ]
 
 [[package]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,5 +57,6 @@ pub use crate::ibidem::ParseWrapper;
 pub use crate::ibidem::TokenStreamWrapper;
 pub use crate::ordered_map::OrderedMap;
 pub use crate::serde_tokenstream::from_tokenstream;
+pub use crate::serde_tokenstream::from_tokenstream_spanned;
 pub use crate::serde_tokenstream::Error;
 pub use crate::serde_tokenstream::Result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,11 @@
 //! # item
 //! # }
 //! ```
+//!
+//! ## Nested attributes
+//!
+//! For attributes that are nested inside a top-level macro, use the
+//! [`from_tokenstream_spanned`] function. See its help for an example.
 
 mod ibidem;
 mod ordered_map;

--- a/src/serde_tokenstream.rs
+++ b/src/serde_tokenstream.rs
@@ -6,7 +6,7 @@ use std::{
     fmt::{self, Display},
 };
 
-use proc_macro2::{Delimiter, Group, TokenStream, TokenTree};
+use proc_macro2::{extra::DelimSpan, Delimiter, Group, TokenStream, TokenTree};
 use quote::ToTokens;
 use serde::de::{
     DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor,
@@ -57,7 +57,66 @@ pub fn from_tokenstream<'a, T>(tokens: &'a TokenStream) -> Result<T>
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = TokenDe::from_tokenstream(tokens);
+    let deserializer = TokenDe::from_tokenstream(None, tokens);
+    from_tokenstream_impl(deserializer)
+}
+
+/// Deserialize an instance of type T from a token stream with data inside,
+/// along with a [`DelimSpan`] for the surrounding braces.
+///
+/// This is useful with nested attributes inside annotations, where
+/// `serde_tokenstream` is used to parse an attribute inside a top-level macro.
+/// In that case, better span information (not just `Span::call_site`) can be
+/// produced.
+///
+/// # Example
+///
+/// The most common use is with `syn::MetaList` instances.
+///
+/// ```
+/// use syn::parse_quote;
+/// use serde::Deserialize;
+/// use serde_tokenstream::from_tokenstream_spanned;
+/// use serde_tokenstream::Result;
+///
+/// fn main() -> Result<()> {
+///     #[derive(Deserialize)]
+///     struct Record {
+///         worker: String,
+///         floor: u32,
+///         region: String,
+///     }
+///     // This is a `syn::MetaList` instance on a nested attribute.
+///     let list: syn::MetaList = parse_quote! {
+///         record {
+///             worker = "Homer J. Simpson",
+///             floor = 7,
+///             region = "G",
+///         }
+///     };
+///
+///     // Use `from_tokenstream_spanned` to get better span information.
+///     let rec = from_tokenstream_spanned::<Record>(list.delimiter.span(), &list.tokens)?;
+///     println!("{} {}{}", rec.worker, rec.floor, rec.region);
+///     Ok(())
+/// }
+///
+/// ```
+pub fn from_tokenstream_spanned<'a, T>(
+    span: &DelimSpan,
+    tokens: &'a TokenStream,
+) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    let deserializer = TokenDe::from_tokenstream(Some(span), tokens);
+    from_tokenstream_impl(deserializer)
+}
+
+fn from_tokenstream_impl<'a, T>(mut deserializer: TokenDe) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
     match T::deserialize(&mut deserializer) {
         // On success, check that there aren't additional, unparsed tokens.
         Ok(result) => match deserializer.next() {
@@ -98,13 +157,17 @@ struct TokenDe {
 }
 
 impl<'de> TokenDe {
-    fn from_tokenstream(input: &'de TokenStream) -> Self {
+    fn from_tokenstream(
+        span: Option<&DelimSpan>,
+        input: &'de TokenStream,
+    ) -> Self {
         // We implicitly start inside a brace-surrounded struct.
         // Constructing a Group allows for more generic handling.
-        TokenDe::new(&TokenStream::from(TokenTree::from(Group::new(
-            Delimiter::Brace,
-            input.clone(),
-        ))))
+        let mut group = Group::new(Delimiter::Brace, input.clone());
+        if let Some(span) = span {
+            group.set_span(span.join());
+        }
+        TokenDe::new(&TokenStream::from(TokenTree::from(group)))
     }
 
     fn new(input: &'de TokenStream) -> Self {

--- a/src/serde_tokenstream.rs
+++ b/src/serde_tokenstream.rs
@@ -71,7 +71,17 @@ where
 ///
 /// # Example
 ///
-/// The most common use is with `syn::MetaList` instances.
+/// The most common use is with [`syn::MetaList`] instances. For example, if
+/// your macro is `#[derive(Record)]` and you're invoked like this:
+///
+/// ```rust,ignore
+/// #[derive(Record)]
+/// #[record { worker = "Homer J. Simpson", floor = 7, region = "G" }]
+/// fn test() {}
+/// ```
+///
+/// Then, the `record` attribute inside can be interpreted as a
+/// `syn::MetaList`. With it in hand:
 ///
 /// ```
 /// use syn::parse_quote;
@@ -86,7 +96,8 @@ where
 ///         floor: u32,
 ///         region: String,
 ///     }
-///     // This is a `syn::MetaList` instance on a nested attribute.
+///
+///     // This is the `syn::MetaList` instance above.
 ///     let list: syn::MetaList = parse_quote! {
 ///         record {
 ///             worker = "Homer J. Simpson",
@@ -95,13 +106,14 @@ where
 ///         }
 ///     };
 ///
-///     // Use `from_tokenstream_spanned` to get better span information.
 ///     let rec = from_tokenstream_spanned::<Record>(list.delimiter.span(), &list.tokens)?;
 ///     println!("{} {}{}", rec.worker, rec.floor, rec.region);
 ///     Ok(())
 /// }
-///
 /// ```
+///
+/// If there's an error like a missing field, it will now be reported with the
+/// span of the braces inside the `record` attribute.
 pub fn from_tokenstream_spanned<'a, T>(
     span: &DelimSpan,
     tokens: &'a TokenStream,

--- a/testlib/Cargo.toml
+++ b/testlib/Cargo.toml
@@ -10,8 +10,10 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1"
+quote = "1.0"
 serde_tokenstream  = { path = ".." }
 serde = { version = "1", features = ["derive"] }
+syn = "2.0"
 
 [dev-dependencies]
 trybuild = "1"

--- a/testlib/src/lib.rs
+++ b/testlib/src/lib.rs
@@ -57,15 +57,14 @@ pub fn outer(
     let annotation_attr =
         item.attrs.iter().find(|attr| attr.path().is_ident("annotation"));
     let annotation_attr = annotation_attr.expect("annotation attribute found");
-    let l = match &annotation_attr.meta {
-        syn::Meta::List(l) => l,
-        _ => {
-            panic!("annotation attribute must be a list")
-        }
+    let syn::Meta::List(list) = &annotation_attr.meta else {
+        panic!("annotation attribute must be a list")
     };
 
-    match from_tokenstream_spanned::<Annotation>(l.delimiter.span(), &l.tokens)
-    {
+    match from_tokenstream_spanned::<Annotation>(
+        list.delimiter.span(),
+        &list.tokens,
+    ) {
         Ok(_) => {
             // Strip the annotation attribute from the function.
             let mut item = item.clone();

--- a/testlib/src/lib.rs
+++ b/testlib/src/lib.rs
@@ -3,8 +3,11 @@
 //! Simple proc macro consumer of `serde_tokenstream` that we use for testing
 //! various failure cases.
 
+use quote::ToTokens;
 use serde::Deserialize;
 use serde_tokenstream::from_tokenstream;
+use serde_tokenstream::from_tokenstream_spanned;
+use syn::parse_macro_input;
 
 #[derive(Deserialize)]
 #[allow(dead_code)]
@@ -41,6 +44,34 @@ pub fn annotation(
 ) -> proc_macro::TokenStream {
     match from_tokenstream::<Annotation>(&attr.into()) {
         Ok(_) => item,
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_attribute]
+pub fn outer(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let item = parse_macro_input!(item as syn::ItemFn);
+    let annotation_attr =
+        item.attrs.iter().find(|attr| attr.path().is_ident("annotation"));
+    let annotation_attr = annotation_attr.expect("annotation attribute found");
+    let l = match &annotation_attr.meta {
+        syn::Meta::List(l) => l,
+        _ => {
+            panic!("annotation attribute must be a list")
+        }
+    };
+
+    match from_tokenstream_spanned::<Annotation>(l.delimiter.span(), &l.tokens)
+    {
+        Ok(_) => {
+            // Strip the annotation attribute from the function.
+            let mut item = item.clone();
+            item.attrs.retain(|attr| attr.path().is_ident("annotation"));
+            item.into_token_stream().into()
+        }
         Err(err) => err.to_compile_error().into(),
     }
 }

--- a/tests/ui/missing_field3.rs
+++ b/tests/ui/missing_field3.rs
@@ -1,0 +1,11 @@
+// Copyright 2020 Oxide Computer Company
+
+use testlib::outer;
+
+#[outer]
+#[annotation {
+    string = "hey"
+}]
+fn test() {}
+
+fn main() {}

--- a/tests/ui/missing_field3.stderr
+++ b/tests/ui/missing_field3.stderr
@@ -1,0 +1,8 @@
+error: missing field `options`
+ --> tests/ui/missing_field3.rs:6:14
+  |
+6 |   #[annotation {
+  |  ______________^
+7 | |     string = "hey"
+8 | | }]
+  | |_^

--- a/tests/ui/missing_field4.rs
+++ b/tests/ui/missing_field4.rs
@@ -1,0 +1,14 @@
+// Copyright 2020 Oxide Computer Company
+
+use testlib::outer;
+
+#[outer]
+#[annotation {
+    nested = {
+        gosling = 0.0,
+        eyas = 0,
+    }
+}]
+fn test() {}
+
+fn main() {}

--- a/tests/ui/missing_field4.stderr
+++ b/tests/ui/missing_field4.stderr
@@ -1,0 +1,9 @@
+error: missing field `squeaker`
+  --> tests/ui/missing_field4.rs:7:14
+   |
+7  |       nested = {
+   |  ______________^
+8  | |         gosling = 0.0,
+9  | |         eyas = 0,
+10 | |     }
+   | |_____^


### PR DESCRIPTION
Currently, if there's a top-level error in the macro (e.g. a top-level missing
field), then we always get a call_site error. That is because we don't have the
span information corresponding to the outer braces.

This isn't a huge problem if serde_tokenstream is used for the top-level
attribute, but does become one for nested attributes. Trait-based Dropshot
servers are one such case -- `endpoint` annotations are nested under the
top-level and can be pretty far from the call site.

Address this by providing an alternative API that also accepts delimiter spans.

Also remove the `.vscode/settings.json` that's no longer required,
and allow the `target` gitignore rule to match a symlink (all my target
directories are symlinks to a non-btrfs-snapshotted store).
