### PR TITLE
doc comment editing pass

### DIFF
--- a/src/ibidem.rs
+++ b/src/ibidem.rs
@@ -5,11 +5,20 @@ use std::cell::RefCell;
 use proc_macro2::{TokenStream, TokenTree};
 use serde::{de::Error, de::Visitor, Deserialize};
 
-/// A Wrapper around proc_macro2::TokenStream that is Deserializable, albeit
-/// only in the context of from_tokenstream(). You can use this if, say, your
-/// macro allows users to pass in Rust tokens as a configuration option. This
-/// can be useful, for example, in a macro that generates code where the caller
-/// of that macro might want to augment the generated code.
+/// A wrapper around [`TokenStream`] that implements [`Deserialize`] in the
+/// context of [`from_tokenstream`].
+///
+/// You can use this if, say, your macro allows users to pass in Rust tokens as
+/// a configuration option. This can be useful, for example, in a macro that
+/// generates code where the caller of that macro might want to augment the
+/// generated code.
+///
+/// # Panics
+///
+/// The [`Deserialize`] implementation for `TokenStreamWrapper` will panic if
+/// it is not used in the context of [`from_tokenstream`].
+///
+/// [`from_tokenstream`]: crate::from_tokenstream
 #[derive(Debug)]
 pub struct TokenStreamWrapper(TokenStream);
 
@@ -36,10 +45,19 @@ impl std::ops::Deref for TokenStreamWrapper {
     }
 }
 
-/// A wrapper around the syn::parse::Parse trait that is Deserializable, albeit
-/// only in the context of from_tokenstream(). This extends
-/// [TokenStreamWrapper] by further interpreting the TokenStream and guiding
-/// the user in the case of parse errors.
+/// A wrapper around `syn`'s [`Parse`] trait that implements [`Deserialize`] in
+/// the context of [`from_tokenstream`].
+///
+/// This extends [`TokenStreamWrapper`] by further interpreting the TokenStream
+/// and guiding the user in the case of parse errors.
+///
+/// # Panics
+///
+/// The [`Deserialize`] implementation for [`TokenStreamWrapper`] will panic if
+/// it is not used in the context of [`from_tokenstream`].
+///
+/// [`Parse`]: syn::parse::Parse
+/// [`from_tokenstream`]: crate::from_tokenstream
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub struct ParseWrapper<P: syn::parse::Parse>(P);
 

--- a/src/ordered_map.rs
+++ b/src/ordered_map.rs
@@ -4,15 +4,10 @@ use std::marker::PhantomData;
 
 use serde::{de::Visitor, Deserialize};
 
-/// A container to deserialize maps into if the keys are non-unique, or don't
-/// implement `Hash` or `Ord`.
+/// A container for pairs that are deserialized from map syntax if the keys are
+/// non-unique, or don't implement `Hash` or `Ord`.
 ///
-/// This is a simple wrapper around a `Vec` of key-value pairs. It doesn't
-/// check for uniqueness of keys, so it's possible to have multiple values for
-/// the same key.
-///
-/// Because this map lacks any trait requirements, directly looking up keys is
-/// not possible. To extract data, call `.into_iter()` on it.
+/// To extract data, call `.into_iter()` on it.
 pub struct OrderedMap<K, V> {
     items: Vec<(K, V)>,
 }

--- a/src/ordered_map.rs
+++ b/src/ordered_map.rs
@@ -4,11 +4,15 @@ use std::marker::PhantomData;
 
 use serde::{de::Visitor, Deserialize};
 
-/// This is a container for pairs that are deserialized from map syntax
-/// without requiring the keys to be unique. This is useful for types that
-/// don't implement traits such as `Hash` or `Ord` required for map types that
-/// offer efficient lookups. The only mechanism to extract data is via
-/// `into_iter()`.
+/// A container to deserialize maps into if the keys are non-unique, or don't
+/// implement `Hash` or `Ord`.
+///
+/// This is a simple wrapper around a `Vec` of key-value pairs. It doesn't
+/// check for uniqueness of keys, so it's possible to have multiple values for
+/// the same key.
+///
+/// Because this map lacks any trait requirements, directly looking up keys is
+/// not possible. To extract data, call `.into_iter()` on it.
 pub struct OrderedMap<K, V> {
     items: Vec<(K, V)>,
 }

--- a/src/serde_tokenstream.rs
+++ b/src/serde_tokenstream.rs
@@ -26,7 +26,7 @@ pub type Error = syn::Error;
 /// Alias for a Result with the error type serde_tokenstream::Error.
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Deserialize an instance of type T from a TokenStream.
+/// Deserialize an instance of type `T` from a [`TokenStream`].
 ///
 /// # Example
 /// ```
@@ -61,8 +61,8 @@ where
     from_tokenstream_impl(deserializer)
 }
 
-/// Deserialize an instance of type T from a TokenStream with data inside,
-/// along with a [`DelimSpan`] for the surrounding braces.
+/// Deserialize an instance of type `T` from a [`TokenStream`] with data
+/// inside, along with a [`DelimSpan`] for the surrounding braces.
 ///
 /// This is useful when parsing an attribute nested inside an outer macro. In
 /// that case, better span information (not just `Span::call_site`) can be


### PR DESCRIPTION
Clippy with Rust 1.83 warns on first paragraphs of documentation that are too
long.  Shorten the lines and do some other minor edits.
